### PR TITLE
bring back 'DA_BEGIN' label

### DIFF
--- a/src/lib.typ
+++ b/src/lib.typ
@@ -251,6 +251,7 @@
     },
   )
   set heading(numbering: "1.1")
+  [#metadata("DA_BEGIN")<DA_BEGIN>]
   body
   if not disable-cover {
     util.insert-blank-page()


### PR DESCRIPTION
As described by my comment in issue #28, this is not a bug with the page numbering, but a bug with the missing "DA_BEGIN" label.