### PR TITLE
Allow for adding glossary entries without an abbreviation

### DIFF
--- a/src/lib/abbr.typ
+++ b/src/lib/abbr.typ
@@ -1,8 +1,8 @@
 #import "util.typ": to-string
 #import "global.typ" as global
 
-#let display(abbr, display) = {
-  link(label("ABBR_DES_" + abbr))[#display#label("ABBR_" + abbr)]
+#let display(abbr, display, link-glossary: false) = {
+  link(if link-glossary { label("ABBR_G_" + abbr) } else { label("ABBR_DES_" + abbr) })[#display#label("ABBR_" + abbr)]
   // Create footnote
   let abbr_state = global.abbr.get().at(abbr)
   let desc = abbr_state.at("footnote", default: abbr_state.at("description", default: none))
@@ -26,7 +26,7 @@
   if value == none {
     panic(length + " for '" + name + "' does not exist in " + form + " form!")
   }
-  display(name, value)
+  display(name, value, link-glossary: not abbr-dict.keys().contains("short"))
 }
 
 #let short(abbr) = {

--- a/src/lib/bubble.typ
+++ b/src/lib/bubble.typ
@@ -64,10 +64,6 @@
   )
 }
 
-#let inline-shape(value) = context {
-
-}
-
 #let inline(body) = {
   set text(fill: BC.todo.text)
   let outset = 2pt

--- a/src/lib/pages/abbreviation.typ
+++ b/src/lib/pages/abbreviation.typ
@@ -9,7 +9,7 @@
       #let abbr = global.abbr.get().at(name)
       #let short = abbr.at("short", default: none)
       #if short == none {
-        panic("Short for '" + name + "' does not exist!")
+        continue
       }
       #let short = short.at("singular", default: none)
       #if short == none {


### PR DESCRIPTION
Um einen Glossareintrag hinzuzufügen, ohne diesen als Abkürzung einzutragen, kann einfach die `short`-Form im `abbr.yml` weggelassen werden.