### PR TITLE
make bib and abbr independent of disable-cover

### DIFF
--- a/src/lib.typ
+++ b/src/lib.typ
@@ -299,19 +299,17 @@
   counter(page).update(1)
   [#metadata("DA_BEGIN")<DA_BEGIN>]
   body
-  if not disable-cover {
+  util.insert-blank-page()
+  set heading(numbering: none)
+  if abbreviation != none {
+    pages.abbreviation.create-page()
     util.insert-blank-page()
-    set heading(numbering: none)
-    if abbreviation != none {
-      pages.abbreviation.create-page()
-      util.insert-blank-page()
-      pages.glossary.create-page()
-      util.insert-blank-page()
-    }
-    if bibliography-content != none {
-      pages.bibliography.create-page(bibliography: bibliography-content)
-      util.insert-blank-page()
-    }
+    pages.glossary.create-page()
+    util.insert-blank-page()
+  }
+  if bibliography-content != none {
+    pages.bibliography.create-page(bibliography: bibliography-content)
+    util.insert-blank-page()
   }
   if print-ref {
     pages.printref.create-page()


### PR DESCRIPTION
If there are no abbreviation they will be omitted, and if there are no bibliography entries they will also be omitted.